### PR TITLE
Improve user interface by named actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,8 @@ A tool to help manage nginx configuration files.
 Synopsis
 --------
 
-ngx-conf [-h] (-e | -d | -x | -l) [-f] [-r] [-v] FILE [FILES]
+ngx-conf [-h] [-f] [-r] [-v] {enable|disable|remove} NAME..
+ngx-conf [-h] [-f] [-v] list
 
 Description
 -----------
@@ -17,42 +18,48 @@ case of configuration files in conf.d/\*.conf, it will handle renaming files to
 an enabled/disabled state. In sites-{enabled,available}/\*, it will handle the
 creation and removal of symbolic links.
 
+Options:
+
 **-h, --help**
   show a help message and exit
-**-e, --enable**
-  enable a configuration files
-**-d, --disable**
-  disable a configuration files
-**-x, --remove**
-  remove a configuration files; will prompt without -f
-**-l, --list**
-  list configuration files
 **-f, --force**
   force change, even if doing so will destroy data
 **-r, --reload**
   reload configuration after change
 **-v, --verbose**
   show verbose output; default is quiet unless errors
-**FILES**
+
+Actions:
+
+**enable**
+  enable one or more sites by name
+**disable**
+  disable one or more sites by name
+**remove**
+  remove one or more sites by name; will prompt without **-f**
+**list**
+  list all available site configuration files
+
+**NAME**
   a list of configuration files to update
 
-Using --force:
+Using --force has the following effects:
 
-* In --remove will not prompt you to delete the file(s).
-* In --enable will ignore conflicts.
-* In --disable will ignore conflicts.
-* In --disable will also delete files from sites-enabled.
-
-Only one action (enable|disable|remove|list) can be performed at one time.
+* For the remove action, it will not prompt you to delete the file(s).
+* For the enable action, it will ignore conflicts (overwrite existing files with
+  a symlink).
+* For the disable action, it will ignore conflicts (besides symlinks, remove
+  files too).
+* For the disable action, it will also delete files from sites-enabled.
 
 Examples
 --------
 
-ngx-conf -e site1 site2 site3
+ngx-conf enable site1 site2 site3
   enable "site{1,2,3}" configurations
-ngx-conf -r -d site
+ngx-conf disable -r site
   disable "site" configuration and reload nginx
-ngx-conf -f -r -x site1 site2
+ngx-conf -f remove -r site1 site2
   remove "site{1,2}" configurations without prompting and reload nginx
 
 Configuration Files
@@ -87,10 +94,10 @@ Aliases
 If you're interested in any sort of a2{dis,en}{conf,mod,site}, you can create
 some nice aliases. Examples:
 
-* a2ensite -- alias ngxensite='ngx-conf -e'
-* a2enconf -- alias ngxenconf='ngx-conf -e'
-* a2dissite -- alias ngxdissite='ngx-conf -d'
-* a2disconf -- alias ngxdisconf='ngx-conf -d'
+* a2ensite -- alias ngxensite='ngx-conf enable'
+* a2enconf -- alias ngxenconf='ngx-conf enable'
+* a2dissite -- alias ngxdissite='ngx-conf disable'
+* a2disconf -- alias ngxdisconf='ngx-conf disable'
 
 Bugs
 ----

--- a/ngx-conf
+++ b/ngx-conf
@@ -80,6 +80,7 @@ def parse_arguments():
         parents=[general_parser]
     )
     subparsers = parser.add_subparsers(dest='action')
+    subparsers.required = True
     # Add actual commands
     parser_enable = subparsers.add_parser('enable',
         parents=[general_parser, conf_action_parser],

--- a/ngx-conf
+++ b/ngx-conf
@@ -59,47 +59,56 @@ conf_ext = config_opts.get('DEFAULT', 'conf_ext')
 
 def parse_arguments():
     '''Parse arguments supplied by the user.'''
-    parser = argparse.ArgumentParser(description='nginx configuration helper',
-        epilog='Only one in group (enable|disable|remove|list) is allowed.',
-        usage='ngx-conf [-h] (-e | -d | -x | -l) [-f] [-r] [-v] FILE [FILES]')
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('-e', '--enable', action='store_true',
-        help='enable a configuration files')
-    group.add_argument('-d', '--disable', action='store_true',
-        help='disable a configuration files')
-    group.add_argument('-x', '--remove', action='store_true',
-        help='remove a configuration files; will prompt without -f')
-    group.add_argument('-l', '--list', action='store_true',
-        help='list configuration files')
-    parser.add_argument('-f', '--force', action='store_true',
-        default=config_opts.getboolean('DEFAULT', 'force'),
-        help='force change, even if doing so will destroy data')
-    parser.add_argument('-r', '--reload', action='store_true',
+    # General options which apply to all commands
+    general_parser = argparse.ArgumentParser(add_help=False)
+    general_parser.add_argument('-v', '--verbose', action='store_true',
+        default=config_opts.getboolean('DEFAULT', 'verbose'),
+        help='show verbose output; default is quiet unless errors')
+
+    # Options which apply to some commands related to site conf files
+    conf_action_parser = argparse.ArgumentParser(add_help=False)
+    conf_action_parser.add_argument('-r', '--reload', action='store_true',
         default=config_opts.getboolean('DEFAULT', 'reload'),
         help='reload configuration after change')
-    parser.add_argument('-v', '--verbose', action='store_true',
-        default=config_opts.getboolean('DEFAULT', 'verbose'),
-        help='show verbose output; default is quite unless errors')
-    parser.add_argument('FILES', nargs=argparse.REMAINDER,
-        help='a list of configuration files to update')
+    conf_action_parser.add_argument('NAME', nargs='+',
+        help='one or more configuration (file) names to update')
+    conf_action_parser.add_argument('-f', '--force', action='store_true',
+        default=config_opts.getboolean('DEFAULT', 'force'),
+        help='force change, even if doing so will destroy data')
+
+    parser = argparse.ArgumentParser(description='nginx configuration helper',
+        parents=[general_parser]
+    )
+    subparsers = parser.add_subparsers(dest='action')
+    # Add actual commands
+    parser_enable = subparsers.add_parser('enable',
+        parents=[general_parser, conf_action_parser],
+        help='enable specified site configuration files')
+    parser_disable = subparsers.add_parser('disable',
+        parents=[general_parser, conf_action_parser],
+        help='disable specified site configuration files')
+    parser_remove = subparsers.add_parser('remove',
+        parents=[general_parser, conf_action_parser],
+        help='remove specified site configuration files')
+    parser_list = subparsers.add_parser('list',
+        parents=[general_parser],
+        help='list all available site configuration files')
+
     return parser.parse_args()
 
 
 def main():
     '''Main execution; read arguments and act accordingly.'''
     args = parse_arguments()
-    if args.FILES == [] and not args.list:
-        print('No files specified. These are required.')
-        return False
-    if args.enable:
-        enable_configs(args.FILES, args.verbose, args.force)
-    elif args.disable:
-        disable_configs(args.FILES, args.verbose, args.force)
-    elif args.remove:
-        remove_configs(args.FILES, args.verbose, args.force)
-    elif args.list:
+    if args.action == 'enable':
+        enable_configs(args.NAME, args.verbose, args.force)
+    elif args.action == 'disable':
+        disable_configs(args.NAME, args.verbose, args.force)
+    elif args.action == 'remove':
+        remove_configs(args.NAME, args.verbose, args.force)
+    elif args.action == 'list':
         list_configs()
-    if args.reload and not args.list:
+    if hasattr(args, 'reload') and args.reload:
         reload_nginx()
 
 

--- a/ngx-conf.1
+++ b/ngx-conf.1
@@ -12,7 +12,10 @@
 ngx - a tool to help manage nginx configuration files
 .SH "SYNOPSIS"
 .B ngx-conf
-[-h] (-e | -d | -x | -l) [-f] [-r] [-v] FILE [FILES]
+[-h] [-f] [-r] [-v] {enable | disable | remove} NAME..
+.br
+.B ngx-conf
+[-h] [-f] [-v] list
 .br
 .SH "DESCRIPTION"
 .PP
@@ -29,49 +32,62 @@ with two dashes (`\-'). A summary of options is included below.
 .B \-h, \-\-help
 show a help message and exit
 .TP
-.B \-e, \-\-enable
-enable a configuration files
-.TP
-.B \-d, \-\-disable
-disable a configuration files
-.TP
-.B \-x, \-\-remove
-remove a configuration files; will prompt without -f
-.TP
-.B \-l, \-\-list
-list configuration files
-.TP
 .B \-f, \-\-force
 force change, even if doing so will destroy data
 .TP
 .B \-r, \-\-reload
-reload configuration after change
+reload configuration after change (for \fBenable\fR, \fBdisable\fR and
+\fBremove\fR actions).
 .TP
 .B \-v, \-\-verbose
 show verbose output; default is quiet unless errors
-.B FILES
-a list of configuration files to update
 .PP
-Using --force:
+Using
+.B --force
+has the following effects:
 .IP
-In --remove will not prompt you to delete the file(s).
+For the remove action, it will not prompt you to delete the file(s).
 .br
-In --enable will ignore conflicts.
+For the enable action, it will ignore conflicts (overwrite existing files with a
+symlink).
 .br
-In --disable will ignore conflicts.
+For the disable action, it will ignore conflicts (besides symlinks, remove files
+too).
 .br
-In --disable will also delete files from sites-enabled.
+For the disable action, it will also delete files from sites-enabled.
 .PP
-Only one action (enable|disable|remove|list) can be performed at one time.
+.SH "COMMANDS"
+The following commands are understood:
+.PP
+.B enable NAME..
+.RS
+enable one or more sites by name
+.RE
+.PP
+.B disable NAME..
+.RS
+disable one or more sites by name
+.RE
+.PP
+.B remove NAME..
+.RS
+remove one or more sites by name; will prompt without \fB-f\fR
+.RE
+.PP
+.B list
+.RS
+list all available site configuration files
+.RE
+
 .SH "EXAMPLES"
 .PP
-ngx-conf -e site1 site2 site3
+ngx-conf enable site1 site2 site3
     enable "site{1,2,3}" configurations
 .br
-ngx-conf -r -d site
+ngx-conf disable -r site
     disable "site" configuration and reload nginx
 .br
-ngx-conf -f -r -x site1 site2
+ngx-conf -f remove -r site1 site2
     remove "site{1,2}" configurations without prompting and reload nginx
 .SH "CONFIGURATION FILES"
 .PP


### PR DESCRIPTION
Replace '-edxl' options by an explicit command. Updated help texts to
reflect this change and the implementation as well.

A subparser was used to enable cleaner separation of options versus
commands. Options specific to enable / disable / remove are moved into
those options. This means that `ngx-conf -h` shows some a subset of the
available options and that `ngx-conf enable -h` shows the remainder
('-f' and '-r' options were moved due to this).

Using `ngx-conf list` with a file argument will also result in an error
now.
